### PR TITLE
Added docker templates

### DIFF
--- a/build.docker.json.template
+++ b/build.docker.json.template
@@ -1,0 +1,12 @@
+{
+  "cookbook_path" : "../recipes/cookbooks/",
+  "build" :
+  {
+        "hostname" : "default",
+        "box" : "###box###",
+	"product" : {
+        	"name" : "packages"
+        }
+  }
+}
+

--- a/install.docker.json
+++ b/install.docker.json
@@ -1,0 +1,12 @@
+{
+  "cookbook_path" : "../recipes/cookbooks/",
+  "maxscale" :
+  {
+        "hostname" : "maxscale",
+        "box" : "###box###",
+        "product" : {
+                "name": "maxscale"
+        }
+
+  }
+}

--- a/test/debugtemplate.docker.json
+++ b/test/debugtemplate.docker.json
@@ -4,12 +4,12 @@
   {
         "hostname" : "node0",
         "box" : "ubuntu_trusty_docker",
-        "memory_size" : "1024",
+	"memory_size" : "1024",
 	"product" : {
       		"name": "###product###",
 		"version": "###version###",
-                "cnf_template" : "server1.cnf",
-                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+		"cnf_template" : "server1.cnf",
+		"cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
 	}
 
   },
@@ -22,8 +22,8 @@
         "product" : {
                 "name": "###product###",
                 "version": "###version###",
-                "cnf_template" : "server2.cnf",
-                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+		"cnf_template" : "server2.cnf",
+		"cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
         }
   },
 
@@ -35,8 +35,8 @@
         "product" : {
                 "name": "###product###",
                 "version": "###version###",
-                "cnf_template" : "server3.cnf",
-                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+		"cnf_template" : "server3.cnf",
+		"cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
         }
   },
 
@@ -48,8 +48,8 @@
         "product" : {
                 "name": "###product###",
                 "version": "###version###",
-                "cnf_template" : "server4.cnf",
-                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+		"cnf_template" : "server4.cnf",
+		"cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
         }
   },
 
@@ -62,7 +62,7 @@
                 "name": "galera",
                 "version": "###galera_version###",
                 "cnf_template" : "galera_server1.cnf",
-                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+		"cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
         }
   },
 
@@ -74,8 +74,8 @@
         "product" : {
                 "name": "galera",
                 "version": "###galera_version###",
-                "cnf_template" : "galera_server2.cnf",
-                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+		"cnf_template" : "galera_server2.cnf",
+		"cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
         }
   },
 
@@ -87,8 +87,8 @@
         "product" : {
                 "name": "galera",
                 "version": "###galera_version###",
-                "cnf_template" : "galera_server3.cnf",
-                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+		"cnf_template" : "galera_server3.cnf",
+		"cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
         }
   },
 
@@ -100,19 +100,18 @@
         "product" : {
                 "name": "galera",
                 "version": "###galera_version###",
-                "cnf_template" : "galera_server4.cnf",
-                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+		"cnf_template" : "galera_server4.cnf",
+		"cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
         }
   },
 
   "maxscale" :
   {
         "hostname" : "maxscale",
-        "box" : "###box###",
-        "memory_size" : "1024",
-        "product" : {
-                "name": "maxscale"
-        }
-
+        "box" : "ubuntu_trusty_docker",
+	"product" : {
+        	"name" : "packages"
+        },
+        "memory_size" : "1024"
   }
 }


### PR DESCRIPTION
These templates can be used to install, build and test docker. Also
changed the default template to Ubuntu trusty as the CentOS 7 had problems
installing Chef.
