### PR TITLE
add defining of platform and platform_version to create_env.sh

### DIFF
--- a/test/create_env.sh
+++ b/test/create_env.sh
@@ -16,6 +16,9 @@ export sshopt="$scpopt $sshuser@$IP"
 export no_repo="yes"
 export remove_strip="yes"
 
+export platform=`./mdbci show boxinfo --box-name=$box --field='platform' --silent`
+export platform_version=`./mdbci show boxinfo --box-name=$box --field='platform_version' --silent`
+
 cd $dir
 ~/build-scripts/build.sh
 res=$?


### PR DESCRIPTION
Fix 'cmake is not installed' problem caused by lack od dfinition of 'platform' and 'platform_version' variables in create_env.sh script (setup_vm_script could not be found due to it)
