### PR TITLE
Add slave-skip-errors to master-slave configs

### DIFF
--- a/test-setup-scripts/cnf/server1.cnf
+++ b/test-setup-scripts/cnf/server1.cnf
@@ -11,18 +11,15 @@
 
 # this is only for the mysqld standalone daemon
 [mysqld]
-#log-basename=mar
 log-bin=mar-bin
-#binlog-format=row
-#binlog-format=STATEMENT
 binlog-format=row
 binlog_row_image=full
 server_id=1
-#slave_parallel_threads=2
 user=mysql
 ## x001
 max_long_data_size=1000000000
 innodb_log_file_size=2000000000
+slave-skip-errors=all
 
 # this is only for embedded server
 [embedded]

--- a/test-setup-scripts/cnf/server10.cnf
+++ b/test-setup-scripts/cnf/server10.cnf
@@ -11,13 +11,12 @@
 
 # this is only for the mysqld standalone daemon
 [mysqld]
-#log-basename=mar
 log-bin=mar-bin
-#binlog-format=row
 binlog-format=STATEMENT
 server_id=10
-#slave_parallel_threads=2
 user=mysql
+## x001
+slave-skip-errors=all
 
 # this is only for embedded server
 [embedded]

--- a/test-setup-scripts/cnf/server11.cnf
+++ b/test-setup-scripts/cnf/server11.cnf
@@ -11,13 +11,12 @@
 
 # this is only for the mysqld standalone daemon
 [mysqld]
-#log-basename=mar
 log-bin=mar-bin
-#binlog-format=row
 binlog-format=STATEMENT
 server_id=11
-#slave_parallel_threads=2
 user=mysql
+## x001
+slave-skip-errors=all
 
 # this is only for embedded server
 [embedded]

--- a/test-setup-scripts/cnf/server12.cnf
+++ b/test-setup-scripts/cnf/server12.cnf
@@ -11,13 +11,12 @@
 
 # this is only for the mysqld standalone daemon
 [mysqld]
-#log-basename=mar
 log-bin=mar-bin
-#binlog-format=row
 binlog-format=STATEMENT
 server_id=12
-#slave_parallel_threads=2
 user=mysql
+## x001
+slave-skip-errors=all
 
 # this is only for embedded server
 [embedded]

--- a/test-setup-scripts/cnf/server13.cnf
+++ b/test-setup-scripts/cnf/server13.cnf
@@ -11,13 +11,12 @@
 
 # this is only for the mysqld standalone daemon
 [mysqld]
-#log-basename=mar
 log-bin=mar-bin
-#binlog-format=row
 binlog-format=STATEMENT
 server_id=13
-#slave_parallel_threads=2
 user=mysql
+## x001
+slave-skip-errors=all
 
 # this is only for embedded server
 [embedded]

--- a/test-setup-scripts/cnf/server14.cnf
+++ b/test-setup-scripts/cnf/server14.cnf
@@ -11,13 +11,12 @@
 
 # this is only for the mysqld standalone daemon
 [mysqld]
-#log-basename=mar
 log-bin=mar-bin
-#binlog-format=row
 binlog-format=STATEMENT
 server_id=14
-#slave_parallel_threads=2
 user=mysql
+## x001
+slave-skip-errors=all
 
 # this is only for embedded server
 [embedded]

--- a/test-setup-scripts/cnf/server15.cnf
+++ b/test-setup-scripts/cnf/server15.cnf
@@ -11,13 +11,12 @@
 
 # this is only for the mysqld standalone daemon
 [mysqld]
-#log-basename=mar
 log-bin=mar-bin
-#binlog-format=row
 binlog-format=STATEMENT
 server_id=15
-#slave_parallel_threads=2
 user=mysql
+## x001
+slave-skip-errors=all
 
 # this is only for embedded server
 [embedded]

--- a/test-setup-scripts/cnf/server2.cnf
+++ b/test-setup-scripts/cnf/server2.cnf
@@ -11,18 +11,15 @@
 
 # this is only for the mysqld standalone daemon
 [mysqld]
-#log-basename=mar
 log-bin=mar-bin
-#binlog-format=row
 binlog-format=row
 binlog_row_image=full
-#binlog-format=STATEMENT
 server_id=2
-#slave_parallel_threads=2
 user=mysql
 ## x001
 max_long_data_size=1000000000
 innodb_log_file_size=2000000000
+slave-skip-errors=all
 
 # this is only for embedded server
 [embedded]

--- a/test-setup-scripts/cnf/server3.cnf
+++ b/test-setup-scripts/cnf/server3.cnf
@@ -11,18 +11,15 @@
 
 # this is only for the mysqld standalone daemon
 [mysqld]
-#log-basename=mar
 log-bin=mar-bin
-#binlog-format=row
-#binlog-format=STATEMENT
 binlog-format=row
 binlog_row_image=full
 server_id=3
-#slave_parallel_threads=2
 user=mysql
 ## x001
 max_long_data_size=1000000000
 innodb_log_file_size=2000000000
+slave-skip-errors=all
 
 # this is only for embedded server
 [embedded]

--- a/test-setup-scripts/cnf/server4.cnf
+++ b/test-setup-scripts/cnf/server4.cnf
@@ -11,18 +11,15 @@
 
 # this is only for the mysqld standalone daemon
 [mysqld]
-#log-basename=mar
 log-bin=mar-bin
-#binlog-format=row
-#binlog-format=STATEMENT
 binlog-format=row
 binlog_row_image=full
 server_id=4
-#slave_parallel_threads=2
 user=mysql
 ## x001
 max_long_data_size=1000000000
 innodb_log_file_size=2000000000
+slave-skip-errors=all
 
 # this is only for embedded server
 [embedded]

--- a/test-setup-scripts/cnf/server5.cnf
+++ b/test-setup-scripts/cnf/server5.cnf
@@ -11,13 +11,12 @@
 
 # this is only for the mysqld standalone daemon
 [mysqld]
-#log-basename=mar
 log-bin=mar-bin
-#binlog-format=row
 binlog-format=STATEMENT
 server_id=5
-#slave_parallel_threads=2
 user=mysql
+## x001
+slave-skip-errors=all
 
 # this is only for embedded server
 [embedded]

--- a/test-setup-scripts/cnf/server6.cnf
+++ b/test-setup-scripts/cnf/server6.cnf
@@ -11,13 +11,12 @@
 
 # this is only for the mysqld standalone daemon
 [mysqld]
-#log-basename=mar
 log-bin=mar-bin
-#binlog-format=row
 binlog-format=STATEMENT
 server_id=6
-#slave_parallel_threads=2
 user=mysql
+## x001
+slave-skip-errors=all
 
 # this is only for embedded server
 [embedded]

--- a/test-setup-scripts/cnf/server7.cnf
+++ b/test-setup-scripts/cnf/server7.cnf
@@ -11,13 +11,12 @@
 
 # this is only for the mysqld standalone daemon
 [mysqld]
-#log-basename=mar
 log-bin=mar-bin
-#binlog-format=row
 binlog-format=STATEMENT
 server_id=7
-#slave_parallel_threads=2
 user=mysql
+## x001
+slave-skip-errors=all
 
 # this is only for embedded server
 [embedded]

--- a/test-setup-scripts/cnf/server8.cnf
+++ b/test-setup-scripts/cnf/server8.cnf
@@ -11,13 +11,12 @@
 
 # this is only for the mysqld standalone daemon
 [mysqld]
-#log-basename=mar
 log-bin=mar-bin
-#binlog-format=row
 binlog-format=STATEMENT
 server_id=8
-#slave_parallel_threads=2
 user=mysql
+## x001
+slave-skip-errors=all
 
 # this is only for embedded server
 [embedded]

--- a/test-setup-scripts/cnf/server9.cnf
+++ b/test-setup-scripts/cnf/server9.cnf
@@ -11,13 +11,12 @@
 
 # this is only for the mysqld standalone daemon
 [mysqld]
-#log-basename=mar
 log-bin=mar-bin
-#binlog-format=row
 binlog-format=STATEMENT
 server_id=9
-#slave_parallel_threads=2
 user=mysql
+## x001
+slave-skip-errors=all
 
 # this is only for embedded server
 [embedded]


### PR DESCRIPTION
We don't care if the slave is in an inconsistent state as long as
replication is not stopped. If a slave stops replication due to a database
inconsistency, it will be caused by a bug in a test. This should not
prevent the test from running.