### PR TITLE
Add Nightly flag to snapshot tests

### DIFF
--- a/test/run_test_snapshot.sh
+++ b/test/run_test_snapshot.sh
@@ -83,7 +83,7 @@ cmake .
 make
 
 ./check_backend --restart-galera
-ctest $test_set -VV
+ctest $test_set -VV -D Nightly
 
 ~/build-scripts/test/copy_logs.sh
 


### PR DESCRIPTION
The snapshot tests are now run with the `-D Nightly` dashboard label.