### PR TITLE
Exit if check_backend fails

### DIFF
--- a/test/run_test_snapshot.sh
+++ b/test/run_test_snapshot.sh
@@ -83,6 +83,14 @@ cmake .
 make
 
 ./check_backend --restart-galera
+
+if [ $? -ne 0 ]
+then
+    rm $snapshot_lock_file
+    echo "Failed to check backends"
+    exit 1
+fi
+
 ctest $test_set -VV -D Nightly
 
 ~/build-scripts/test/copy_logs.sh


### PR DESCRIPTION
If the check_backend command fails, the snapshot test run should be
aborted.