### PR TITLE
Add build name to snapshot tests

### DIFF
--- a/test/run_test_snapshot.sh
+++ b/test/run_test_snapshot.sh
@@ -79,7 +79,7 @@ if [ $? != 0 ] ; then
 fi
 
 cd $dir
-cmake .
+cmake . -DBUILDNAME=$JOB_NAME-$BUILD_NUMBER-$target
 make
 
 ./check_backend --restart-galera


### PR DESCRIPTION
The snapshot tests all used the default build name.