### PR TITLE
Clean up and improve build scripts

### DIFF
--- a/install_deb_local.sh
+++ b/install_deb_local.sh
@@ -3,26 +3,21 @@
 # do the real building work
 # this script is executed on build VM
 
-set -x
-
 cd $work_dir
+
+# Check if CMake needs to be installed
+command -v cmake || install_cmake="cmake"
 
 . ~/check_arch.sh
 
-sudo apt-get update
-sudo apt-get install -y dpkg-dev git
+set -x
 
-#sudo apt-get install -y --force-yes cmake
-sudo apt-get install -y --force-yes gcc g++ ncurses-dev bison build-essential libssl-dev libaio-dev perl make libtool 
-#sudo apt-get install -y --force-yes librabbitmq-dev
-sudo apt-get install -y --force-yes libcurl4-openssl-dev
-sudo apt-get install -y --force-yes libpcre3-dev
-sudo apt-get install -y --force-yes flex
-#sudo apt-get install -y --force-yes flex
-sudo apt-get install -y --force-yes tcl
-sudo apt-get install -y --force-yes libeditline-dev
-sudo apt-get install -y --force-yes uuid-dev
-sudo apt-get install -y --force-yes liblzma-dev
+sudo apt-get update
+
+sudo apt-get install -y --force-yes dpkg-dev git gcc g++ ncurses-dev bison \
+     build-essential libssl-dev libaio-dev perl make libtool libcurl4-openssl-dev \
+     libpcre3-dev flex tcl libeditline-dev uuid-dev liblzma-dev libsqlite3-dev \
+     sqlite3 liblua5.1 liblua5.1-dev
 
 if [ $remove_strip == "yes" ] ; then
         sudo rm -rf /usr/bin/strip
@@ -42,9 +37,6 @@ git checkout v0.7.1
 cmake .  -DCMAKE_C_FLAGS=-fPIC -DBUILD_SHARED_LIBS=N -DCMAKE_INSTALL_PREFIX=/usr
 sudo make install
 cd ../../
-
-# SQLite3
-sudo apt-get install -y --force-yes libsqlite3-dev sqlite3
 
 # Jansson
 git clone https://github.com/akheron/jansson.git
@@ -80,7 +72,3 @@ if [ "$use_mariadbd" == "yes" ] ; then
 	sudo tar xzvf $mariadbd_file -C /usr/ --strip-components=1
 	cmake_flags +=" -DERRMSG=/usr/share/english/errmsg.sys -DMYSQL_EMBEDDED_LIBRARIES=/usr/lib/"
 fi
-
-# Install Lua packages
-sudo apt-get -y install liblua5.1 liblua5.1-dev
-

--- a/install_rpm_local.sh
+++ b/install_rpm_local.sh
@@ -16,7 +16,7 @@ then
        make libtool libopenssl-devel libaio libaio-devel flex libcurl-devel \
        pcre-devel git wget tcl libuuid-devel \
        xz-devel sqlite3 sqlite3-devel pkg-config lua lua-devel \
-       $install_cmake
+       rpm-build $install_cmake
 
   cat /etc/*-release | grep "SUSE Linux Enterprise Server 11"
 

--- a/install_rpm_local.sh
+++ b/install_rpm_local.sh
@@ -18,7 +18,7 @@ then
        make libtool libopenssl-devel libaio libaio-devel flex libcurl-devel \
        pcre-devel git wget tcl libuuid-devel \
        xz-devel sqlite3 sqlite3-devel pkg-config lua lua-devel \
-       systemtap-sdt-devel rpm-build $install_cmake
+       $install_cmake
 
   cat /etc/*-release | grep "SUSE Linux Enterprise Server 11"
 

--- a/install_rpm_local.sh
+++ b/install_rpm_local.sh
@@ -10,8 +10,6 @@ command -v cmake || install_cmake="cmake"
 
 command -v yum
 
-set -x
-
 if [ $? -ne 0 ]
 then
   sudo zypper -n install gcc gcc-c++ ncurses-devel bison glibc-devel libgcc_s1 perl \

--- a/install_rpm_local.sh
+++ b/install_rpm_local.sh
@@ -3,21 +3,23 @@
 # Do the real building work. This script is executed on build VM and
 # requires a working installation of CMake.
 
-set -x
-
 cd $work_dir
 
+# Check if CMake needs to be installed
+command -v cmake || install_cmake="cmake"
+
 command -v yum
+
+set -x
 
 if [ $? -ne 0 ]
 then
   sudo zypper -n install gcc gcc-c++ ncurses-devel bison glibc-devel libgcc_s1 perl \
        make libtool libopenssl-devel libaio libaio-devel flex libcurl-devel \
        pcre-devel git wget tcl libuuid-devel \
-       xz-devel sqlite3 sqlite3-devel pkg-config lua lua-devel 
-  sudo zypper -n install systemtap-sdt-devel
-  sudo zypper -n install rpm-build
-# rpmdevtools
+       xz-devel sqlite3 sqlite3-devel pkg-config lua lua-devel \
+       systemtap-sdt-devel rpm-build $install_cmake
+
   cat /etc/*-release | grep "SUSE Linux Enterprise Server 11"
 
   if [ $? -ne 0 ]
@@ -30,7 +32,7 @@ else
        libgcc perl make libtool openssl-devel libaio libaio-devel libedit-devel \
        libedit-devel libcurl-devel curl-devel systemtap-sdt-devel rpm-sign \
        gnupg pcre-devel flex rpmdevtools git wget tcl openssl libuuid-devel xz-devel \
-       sqlite sqlite-devel pkgconfig lua lua-devel rpm-build createrepo yum-utils
+       sqlite sqlite-devel pkgconfig lua lua-devel rpm-build createrepo yum-utils $install_cmake
 
   cat /etc/redhat-release | grep "release 5"
   if [ $? -eq 0 ]


### PR DESCRIPTION
The scripts now install all packages in one command. This removes the
repeated execution of the same command.

If CMake is not installed, the system CMake is used. This allows the
scripts to be used on VMs without a pre-built CMake.