### PR TITLE
Only run testing phase

### DIFF
--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -47,7 +47,9 @@ if [ $res == 0 ] ; then
 	    rm ~/vagrant_lock
 	    exit 1
         fi
-        ctest -VV -D Nightly $test_set
+        ctest -D NightlyStart
+        ctest -VV -D NightlyTest $test_set
+        ctest -D NightlySubmit
         set +x
     else
 	./$named_test


### PR DESCRIPTION
We don't need to run any other parts of the CTest testing process as
everything is already handled by the testing scripts.